### PR TITLE
2.2.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ cmake ^
   -DCMAKE_BUILD_TYPE:String=Release ^
   -GNinja ^
   -DLZ4_LIBRARY=%LIBRARY_LIB%\liblz4.lib ^
+  -DRDKAFKA_BUILD_EXAMPLES=OFF ^
   ..
 
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "librdkafka" %}
-{% set version = "2.1.1" %}
-{% set sha256 = "7be1fc37ab10ebdc037d5c5a9b35b48931edafffae054b488faaff99e60e0108" %}
+{% set version = "2.2.0" %}
+{% set sha256 = "af9a820cbecbc64115629471df7c7cecd40403b6c34bfdbb9223152677a47226" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
## ☆Librdkafka 2.2.0 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2762)
[Upstream](https://github.com/confluentinc/librdkafka)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
-  Turned off drdkafka build examples off due to build failures regarding win64