### PR TITLE
rebuild for openssl1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,8 @@
+#openssl 1.1.x required by customer
+#following does not work, see https://github.com/conda/conda-build/issues/5038
+#openssl:
+#  - 1.1.1
+#  - 3.0
+openssl_variant:
+  - current
+  - legacy

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,8 +1,0 @@
-#openssl 1.1.x required by customer
-#following does not work, see https://github.com/conda/conda-build/issues/5038
-#openssl:
-#  - 1.1.1
-#  - 3.0
-openssl_variant:
-  - current
-  - legacy

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,10 @@
 cyrus_sasl:
   - 2.1.27
+#openssl 1.1.x required by customer
+#following does not work, see https://github.com/conda/conda-build/issues/5038
+#openssl:
+#  - 1.1.1
+#  - 3.0
+openssl_variant:
+  - current
+  - legacy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # np cyrus-sasl on s390x
   skip: True  # [linux and s390x]
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,10 +28,14 @@ requirements:
 
   host:
     - zlib {{ zlib }}
-    - openssl 3.0.8
     - cyrus-sasl 2.1.28  # [not win]
     - lz4-c 1.9.4
     - zstd {{ zstd }}
+    #following does not work, see https://github.com/conda/conda-build/issues/5038
+    #    - openssl {{ openssl }}
+    - openssl 1.1.1 # [openssl_variant == "current"]
+    - openssl 3.0 # [openssl_variant == "legacy"]
+
   run:
     - zlib
     - openssl 3.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
 
   run:
     - zlib
-    - openssl 3.*
+    - openssl
     # cyrus-sasl is not used on windows, instead a native implementation is:
     # https://github.com/edenhill/librdkafka/issues/1381#issuecomment-323382697
     - cyrus-sasl  # [not win]


### PR DESCRIPTION
* [upstream repo](https://github.com/confluentinc/librdkafka/tree/v2.2.0)
* [Jira ticket](https://anaconda.atlassian.net/browse/PKG-3135)
* dependency for [PKG-3092](https://anaconda.atlassian.net/browse/PKG-3092)

Notes:
- used workaround to get conda build to pin `openssl` to two variants (`1.1.1`, `3`) and thus generate two output packages

[PKG-3092]: https://anaconda.atlassian.net/browse/PKG-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ